### PR TITLE
Allow scripts to not have `"use strict";` atop them

### DIFF
--- a/lib/rules/strict-newline.js
+++ b/lib/rules/strict-newline.js
@@ -50,6 +50,10 @@ module.exports = function (context) {
 				}
 			}
 
+			if (!tokens.length) {
+				return;
+			}
+
 			for (token of tokens) {
 				lastToken = sourceCode.getLastToken(token);
 				nextToken = sourceCode.getTokenAfter(token);

--- a/test/lib/rules/strict-newline.js
+++ b/test/lib/rules/strict-newline.js
@@ -11,6 +11,10 @@ var ruleTester = new RuleTester();
 ruleTester.run('strict-newline', rule, {
 	valid: [
 		{
+			code: 'var a;',
+			parserOptions: parserOptions
+		},
+		{
 			code: [
 				'"use strict"',
 				'',


### PR DESCRIPTION
This PR updates the rule to not produce an error when there is no `"use strict";` literal atop the file. This allows something else, some other rule (e.g. [`strict`](http://eslint.org/docs/rules/strict)), to check whether or not `"use strict";` exists (or shouldn't exist, as per below) and for this rule to ensure that *if* the file has `"use strict";` at the top, that it is indeed followed by a newline.

From [this SO answer](http://stackoverflow.com/a/31685340/1267663) on the use of `"use strict";` in ES6 (the emphasis is theirs):

> ES6 modules are always in strict mode. To quote the relevant part of [the spec][1]:
> 
> > ## 10.2.1 Strict Mode Code
> >
> > An ECMAScript Script syntactic unit may be processed using either unrestricted or strict mode syntax and semantics. Code is interpreted as strict mode code in the following situations:
> >
> > * Global code is strict mode code if it begins with a Directive Prologue that contains a Use Strict Directive (see 14.1.1).
> > * **Module code is always strict mode code.**
> > * All parts of a ClassDeclaration or a ClassExpression are strict mode code.
> > * Eval code is strict mode code if it begins with a Directive Prologue that contains a Use Strict Directive or if the call to eval is a direct eval (see 12.3.4.1) that is contained in strict mode code.
> > * Function code is strict mode code if the associated FunctionDeclaration, FunctionExpression, GeneratorDeclaration, GeneratorExpression, MethodDefinition, or ArrowFunction is contained in strict mode code or if the code that produces the value of the function’s [[ECMAScriptCode]] internal slot begins with a Directive Prologue that contains a Use Strict Directive.
> > * Function code that is supplied as the arguments to the built-in Function and Generator constructors is strict mode code if the last argument is a String that when processed is a FunctionBody that begins with a Directive Prologue that contains a Use Strict Directive.


  [1]: http://www.ecma-international.org/ecma-262/6.0/#sec-strict-mode-code

This is all well and good, but if a project has mixed ES6 and ES5 code (e.g. a React app using ES6 modules + webpack but with some configuration scripts or build scripts using plain ol' ES5), some files will not have a `"use strict";` atop them and ESLint will complain. I ended up in a situation where I couldn't appease ESLint by adding `"use strict"`:

```
src/App.js
  1:1  error  'use strict' is unnecessary inside of modules  strict
```

Or by removing `"use strict";`:

```
src/App.js
  1:1  error  Expected newline after 'use strict'  strict-newline/strict-newline
```

Right now, I am simply disabling the `strict-newline/strict-newline` rule on a directory-by-directory basis, but it would be ideal if I could not have to do that.
